### PR TITLE
Skip messages with corrupt GZip data

### DIFF
--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -119,6 +119,8 @@ public class MessageReader {
             } catch (Exception e) {
                 if (e instanceof ZipException) {
                     LOG.warn(String.format("Corrupt GZIP data, skipping message: %s", e.getMessage()), e);
+                } else if (e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
                 } else {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -113,12 +113,17 @@ public class MessageReader {
     }
 
     public boolean hasNext() {
-        while (true) {
+        for (int i = 0; i < 10; i++) {
             try {
                 return mIterator.hasNext();
             } catch (Exception e) {
                 if (e instanceof ZipException) {
                     LOG.warn(String.format("Corrupt GZIP data, skipping message: %s", e.getMessage()), e);
+                    try {
+                      mIterator.next();
+                    } catch (Exception ignored) {
+                      LOG.warn(String.format("Error while skipping message, suppressed: %s", e.getMessage()), e);
+                    }
                 } else if (e instanceof RuntimeException) {
                     throw (RuntimeException) e;
                 } else {
@@ -126,6 +131,7 @@ public class MessageReader {
                 }
             }
         }
+        throw new RuntimeException("Too many failures while trying to find out if there is a next message");
     }
 
     public Message read() {

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.zip.ZipException;
 
 /**
  * Message reader consumer raw Kafka messages.
@@ -112,7 +113,17 @@ public class MessageReader {
     }
 
     public boolean hasNext() {
-        return mIterator.hasNext();
+        while (true) {
+            try {
+                return mIterator.hasNext();
+            } catch (Exception e) {
+                if (e instanceof ZipException) {
+                    LOG.warn(String.format("Corrupt GZIP data, skipping message: %s", e.getMessage()), e);
+                } else {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 
     public Message read() {


### PR DESCRIPTION
This is a fix for a very special case, not for general use.